### PR TITLE
bugfix: focus to the desktop in focused monitor.

### DIFF
--- a/examples/example_001.py
+++ b/examples/example_001.py
@@ -232,7 +232,7 @@ class BSPWM(Module):
             return
 
         desktop = event[event.rindex('_')+1:]
-        sp.Popen(['bspc', 'desktop', '--focus', desktop])
+        sp.Popen(['bspc', 'desktop', '--focus', desktop + '.local'])
 
 
 # Define the modules to put on the bar (in order)


### PR DESCRIPTION
Removes the conflict when you clicking on a desktop label that has the same name on another monitor.